### PR TITLE
Deploy data sites from the repository's default branch

### DIFF
--- a/.github/workflows/data-deploy.yml
+++ b/.github/workflows/data-deploy.yml
@@ -57,7 +57,10 @@ jobs:
       - uses: actions/upload-pages-artifact@v3
 
   deploy:
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
+    # Deploy from the repository's default branch. Hardcoding master/main
+    # excluded relaton-data-* repos that have moved their default branch
+    # (e.g. v2), causing fresh data to be built but never published.
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     needs: build_index_page
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment


### PR DESCRIPTION
## Summary

The `deploy` job in `data-deploy.yml` is gated on `refs/heads/master` / `refs/heads/main`. Some `relaton-data-*` repos (e.g. [relaton-data-w3c](https://github.com/relaton/relaton-data-w3c)) have moved their default branch to `v2`, where the daily crawler now writes fresh `index-v1.{yaml,zip}` and `data/`. The `build_index_page` job runs (cron fires on default branch) and produces a correct artifact, but the `deploy` step is always skipped, so the live `https://relaton.github.io/...` sites stop getting fresh data.

Concretely on relaton-data-w3c@v2: [build run 25413796786](https://github.com/relaton/relaton-data-w3c/actions/runs/25413796786) — `build_index_page: success`, `deploy: skipped`.

This PR switches the gate to the repository's default branch:

```diff
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
+    # Deploy from the repository's default branch. Hardcoding master/main
+    # excluded relaton-data-* repos that have moved their default branch
+    # (e.g. v2), causing fresh data to be built but never published.
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
```

Behavior preserved for repos still on `master`/`main` as default; new behavior lights up automatically for repos whose default has moved.

## Test plan

- [ ] After merge, re-run Deploy on `relaton-data-w3c@v2` and confirm `deploy` runs (not skipped) and the live site at https://relaton.github.io/relaton-data-w3c/ updates.
- [ ] Confirm any repo still on `main`/`master` default deploys exactly as today.