### PR TITLE
Add reusable keep-alive workflow (API-based)

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -5,14 +5,16 @@ on:
     inputs:
       workflows:
         description: >
-          Space-separated list of workflow filenames to re-enable (e.g. "crawler.yml release.yml").
-          If empty (default), every workflow in the calling repo is re-enabled.
+          Space-separated list of workflow filenames or numeric IDs to re-enable
+          (e.g. "crawler.yml release.yml"). If empty (default), every workflow
+          in the calling repo is auto-discovered and re-enabled.
         required: false
         default: ''
         type: string
       exclude:
         description: >
-          Space-separated list of workflow filenames to skip when `workflows` is empty.
+          Space-separated list of workflow filenames to skip during auto-discovery.
+          Ignored when `workflows` is set explicitly.
         required: false
         default: ''
         type: string
@@ -32,14 +34,23 @@ jobs:
           EXCLUDE: ${{ inputs.exclude }}
         run: |
           set -euo pipefail
-          if [ -z "$WORKFLOWS" ]; then
-            WORKFLOWS=$(gh api "/repos/$REPO/actions/workflows" --paginate \
-              --jq '.workflows[].path | sub("^\\.github/workflows/"; "")' \
-              | tr '\n' ' ')
+          enable() {
+            local ref="$1" label="$2"
+            echo "Re-enabling $label"
+            if ! gh api -X PUT "/repos/$REPO/actions/workflows/$ref/enable"; then
+              echo "  (warning: could not re-enable $label)"
+            fi
+          }
+          if [ -n "$WORKFLOWS" ]; then
+            for wf in $WORKFLOWS; do enable "$wf" "$wf"; done
+          else
+            # Auto-discover by numeric id (handles dynamic workflows like CodeQL
+            # whose path is not under .github/workflows/ and cannot be enabled by name)
+            gh api "/repos/$REPO/actions/workflows" --paginate \
+              --jq '.workflows[] | "\(.id)\t\(.path)"' \
+              | while IFS=$'\t' read -r id path; do
+                  name="${path#.github/workflows/}"
+                  case " $EXCLUDE " in *" $name "*) echo "Skipping $name"; continue ;; esac
+                  enable "$id" "$path"
+                done
           fi
-          for wf in $WORKFLOWS; do
-            case " $EXCLUDE " in *" $wf "*) echo "Skipping $wf"; continue ;; esac
-            echo "Re-enabling $wf"
-            gh api -X PUT "/repos/$REPO/actions/workflows/$wf/enable" \
-              || echo "  (warning: could not re-enable $wf)"
-          done

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,45 @@
+name: keep-alive
+
+on:
+  workflow_call:
+    inputs:
+      workflows:
+        description: >
+          Space-separated list of workflow filenames to re-enable (e.g. "crawler.yml release.yml").
+          If empty (default), every workflow in the calling repo is re-enabled.
+        required: false
+        default: ''
+        type: string
+      exclude:
+        description: >
+          Space-separated list of workflow filenames to skip when `workflows` is empty.
+        required: false
+        default: ''
+        type: string
+
+jobs:
+  keep-alive:
+    name: Keep alive GHA
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Re-enable workflows via API
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          WORKFLOWS: ${{ inputs.workflows }}
+          EXCLUDE: ${{ inputs.exclude }}
+        run: |
+          set -euo pipefail
+          if [ -z "$WORKFLOWS" ]; then
+            WORKFLOWS=$(gh api "/repos/$REPO/actions/workflows" --paginate \
+              --jq '.workflows[].path | sub("^\\.github/workflows/"; "")' \
+              | tr '\n' ' ')
+          fi
+          for wf in $WORKFLOWS; do
+            case " $EXCLUDE " in *" $wf "*) echo "Skipping $wf"; continue ;; esac
+            echo "Re-enabling $wf"
+            gh api -X PUT "/repos/$REPO/actions/workflows/$wf/enable" \
+              || echo "  (warning: could not re-enable $wf)"
+          done


### PR DESCRIPTION
## Summary

Adds `.github/workflows/keep-alive.yml` as a reusable workflow (`workflow_call`) that `relaton-data-*` repos can call to prevent the 60-day-inactivity scheduled-workflow disable.

## Why

The existing chain `relaton-data-*/keep-alive.yml → metanorma/ci/keep-alive.yml@main → gautamkrishnar/keepalive-workflow@v1` has been failing every monthly run since 2025-05-01 with **"Repository access blocked"**. Investigation:

\`\`\`
$ gh api repos/gautamkrishnar/keepalive-workflow
{"message":"Repository access blocked",
 "block":{"reason":"tos","created_at":"2025-04-21T23:04:42Z"}}
\`\`\`

GitHub blocked the leaf action on **2025-04-21** for ToS violation (dummy commits to defeat the inactivity policy). The block is repo-wide — every ref (v1, v2, master, any SHA) is unreachable. Re-versioning won't fix it.

## Design

- Uses GitHub's official `PUT /repos/{owner}/{repo}/actions/workflows/{id}/enable` REST API instead of dummy commits. ToS-clean.
- No third-party actions, no `uses:` — only the preinstalled `gh` CLI.
- Auto-discovers workflows in the calling repo by default; optional `workflows` / `exclude` inputs.
- Requires only `actions: write` permission, declared on the job.

## Caller usage

\`\`\`yaml
name: keep-alive
on:
  schedule:
  - cron: "0 0 1 * *"
  workflow_dispatch:

jobs:
  keep-alive:
    uses: relaton/support/.github/workflows/keep-alive.yml@main
\`\`\`

A companion PR to `relaton/relaton-data-etsi` switches its caller to this workflow. If green, the same caller change can be swept across other `relaton-data-*` repos showing the same failure.

## Test plan

- [x] Merge this PR.
- [x] Open companion PR on `relaton/relaton-data-etsi` (branch `v2`) repointing its `keep-alive.yml` caller to `relaton/support/.github/workflows/keep-alive.yml@main`.
- [x] After both merged, trigger via `gh workflow run keep-alive.yml --repo relaton/relaton-data-etsi` and confirm green run with log lines `Re-enabling crawler.yml` / `Re-enabling keep-alive.yml` (HTTP 204 responses).
- [ ] Sweep other failing `relaton-data-*` repos (e.g. `relaton-data-iso`).
- [ ] Follow-up: update `metanorma/cimas` template to emit the new caller pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)