### PR TITLE
Declare explicit GITHUB_TOKEN permissions on rake/release wrappers

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -14,6 +14,10 @@ on:
     secrets:
       pat_token:
         required: false
+
+permissions:
+  contents: write
+
 jobs:
   rake:
     uses: metanorma/ci/.github/workflows/generic-rake.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ on:
 permissions:
   id-token: write
   contents: write
+  packages: write
 
 jobs:
   release:


### PR DESCRIPTION
## Summary

Add explicit `permissions:` blocks to the two reusable-workflow wrappers shipped from this repo, so consumer repos (relaton-render, relaton, relaton-cli, relaton-bib, …) regain a write-capable `GITHUB_TOKEN` for their `tests-passed` and release steps under GitHub's new default-restrictive permissions model.

## Why

GitHub now defaults the auto-injected `GITHUB_TOKEN` to read-only for workflows that don't declare a `permissions:` block. Crucially, the effective permission for a job is **capped by the most-restrictive workflow in the reusable-workflow chain** — a missing block at an intermediate wrapper constrains everything below it, regardless of what the outer caller declared.

The visible failure: on [relaton-render run 25682839639](https://github.com/relaton/relaton-render/actions/runs/25682839639) (and its merge-commit counterpart [25706896271](https://github.com/relaton/relaton-render/actions/runs/25706896271)), the `tests-passed` step in the `rake` workflow fails with `Resource not accessible by integration` from `peter-evans/repository-dispatch@v3`. The job's `GITHUB_TOKEN Permissions` group in the run log shows only `Contents: read, Metadata: read`. `repository_dispatch` needs `contents: write`.

The call chain for relaton-render's `rake` workflow is:

```
relaton-render/.github/workflows/rake.yml         [declares contents: write — correct]
  └── uses: relaton/support/.github/workflows/rake.yml@main   [no permissions block — choke point]
        └── uses: metanorma/ci/.github/workflows/generic-rake.yml@main   [fixed by metanorma/ci#275]
```

Hassan's [metanorma/ci#275](https://github.com/metanorma/ci/pull/275) (merged 2026-05-12) fixed the innermost worker by adding `permissions: contents: write` to the `tests-passed` job. But because relaton's consumer repos route through this `relaton/support` wrapper, and the wrapper had no `permissions:` block of its own, the chain remained capped at the wrapper level. This PR fixes that.

## Changes

**`.github/workflows/rake.yml`** — add a workflow-level `permissions:` block:

```yaml
permissions:
  contents: write
```

This makes `contents: write` the cap for the worker reusable workflow (`metanorma/ci/generic-rake.yml`), so its `tests-passed` job's `contents: write` request is honoured.

**`.github/workflows/release.yml`** — extend the existing `permissions:` block with `packages: write`:

```yaml
permissions:
  id-token: write
  contents: write
  packages: write  # new
```

This aligns the release wrapper with the recommended three-permission baseline for release workflows. Same failure mode would have hit the next release otherwise.

## Why not patch `cimas-config/gh-actions/master/rake.yml` too?

The consumer-repo template already emits `permissions: contents: write` at the workflow level in every generated `.github/workflows/rake.yml` (e.g. relaton-render's). The consumer end is fine; the gap is exclusively at the wrapper layer touched by this PR.

## Test plan

- [x] Merge this PR (no inline test possible — `relaton/support` reusable workflows have no consumers in this repo itself).
- [ ] On relaton-render, re-run a `rake` workflow (re-run [25706896271](https://github.com/relaton/relaton-render/actions/runs/25706896271) or push a no-op commit). Confirm:
  - The `tests-passed` job's `GITHUB_TOKEN Permissions` group now lists `Contents: write`.
  - The `Tests passed` step succeeds with no `Resource not accessible by integration`.
- [ ] On the next tagged release of a relaton-org gem, confirm the release workflow's `release` job runs without permission errors against `packages:` operations.

## Out of scope

- Changes to consumer repos (`relaton-render`, `relaton-cli`, etc.) — their `.github/workflows/rake.yml` / `release.yml` are auto-generated by cimas and already declare the correct outer permission. Nothing to do there.
- Other reusable workflows in this repo (`make.yml`, `crawler.yml`, `data-deploy.yml`, etc.) — not implicated in the failing chain. Worth a follow-up audit if `@ronaldtse` wants a broader sweep.

---

cc @ronaldtse @HassanAkbar — context from the chat thread that prompted this. Default maintainer per project records is `@andrew2net` — assigning for review.
