### PR TITLE
Add reusable rake-monorepo workflow

### DIFF
--- a/.github/workflows/rake-monorepo.yml
+++ b/.github/workflows/rake-monorepo.yml
@@ -1,0 +1,183 @@
+name: rake-monorepo
+
+# Reusable workflow for monorepos that hold many gems under a single
+# directory (one Gemfile / gemspec per gem). Builds a gem × ruby × os
+# matrix and runs `bundle exec rake` in each gem's directory.
+#
+# Upstream metanorma/ci's generic-rake.yml only handles single-gem repos.
+# Use this one when the caller has e.g. gems/<name>/ subdirectories.
+
+on:
+  workflow_call:
+    inputs:
+      gem_directory:
+        description: 'Directory containing per-gem subdirectories'
+        required: false
+        type: string
+        default: 'gems'
+      ruby_versions:
+        description: >-
+          Comma-separated allowlist of Ruby versions to keep from the upstream
+          ruby-matrix.json (e.g. "3.4,4.0"). Empty means "use all of upstream".
+        required: false
+        type: string
+        default: ''
+      tests-passed-event:
+        description: 'Name of event sent with repository-dispatch after rake tests are passed successfully'
+        required: false
+        type: string
+        default: 'tests-passed'
+      release-event:
+        description: 'Name of event sent to initiate release'
+        required: false
+        type: string
+        default: 'do-release'
+    secrets:
+      pat_token:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      head_tag: ${{ steps.check.outputs.head_tag }}
+      foreign_pr: ${{ steps.check.outputs.foreign_pr }}
+      push_for_tag: ${{ steps.push_for_tag.outputs.value }}
+      combined_matrix: ${{ steps.combined_matrix.outputs.value }}
+      default_ruby_version: ${{ steps.combined_matrix.outputs.default_ruby_version }}
+      public: ${{ steps.repo_status.outputs.public }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: retrieve tags
+        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* || true
+
+      - name: set output variables
+        id: check
+        run: |
+          fpr="no"
+          tag=""
+          if [[ "${{ github.ref }}" == refs/heads/* ]]; then
+            tag="$(git tag --points-at HEAD)"
+          elif [[ "${{ github.ref }}" == refs/pull/* ]] && [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.event.pull_request.base.repo.full_name }}" ]; then
+            fpr="yes"
+          fi
+          echo "foreign_pr=${fpr}" >> $GITHUB_OUTPUT
+          echo "head_tag=${tag}" >> $GITHUB_OUTPUT
+
+      - name: Push for tag
+        id: push_for_tag
+        shell: python
+        run: |
+          import os
+          event_name = '${{ github.event_name }}'
+          head_tag = '${{ steps.check.outputs.head_tag }}'
+          excluded_events = ['pull_request', 'workflow_dispatch', 'repository_dispatch', 'cron']
+          is_excluded_event = event_name in excluded_events
+          push_condition = event_name == 'push' and head_tag == ''
+          result = str(not (is_excluded_event or push_condition)).lower()
+          os.system(f"echo value={result} >> {os.environ['GITHUB_OUTPUT']}")
+
+      - name: Build combined matrix
+        id: combined_matrix
+        run: |
+          # GitHub Actions caps a single matrix at 256 jobs. With a sensible
+          # ruby_versions filter (e.g. "3.4,4.0") the full cross-product is
+          # gems × rubies × oses; check yours stays under 256.
+          ruby_matrix="$(curl -sL https://raw.githubusercontent.com/metanorma/ci/main/.github/workflows/ruby-matrix.json)"
+          if [ -d "${{ inputs.gem_directory }}" ]; then
+            gems_array="$(ls ${{ inputs.gem_directory }}/ | jq -R -s -c 'split("\n")[:-1]')"
+          else
+            gems_array='[]'
+          fi
+          allow='${{ inputs.ruby_versions }}'
+
+          combined=$(echo "$ruby_matrix" | jq --argjson gems "$gems_array" --arg allow "$allow" '
+            (if $allow == "" then .ruby
+             else .ruby | map(select(.version as $v | ($allow | split(",") | index($v))))
+             end) as $ruby_configs |
+            $gems as $gem_list |
+            .os as $os_list |
+            {
+              "include": [
+                $gem_list[] as $gem |
+                $ruby_configs[] as $ruby |
+                $os_list[] as $os |
+                { "gem": $gem, "ruby": $ruby, "os": $os }
+              ]
+            }
+          ')
+
+          # Default ruby = first non-experimental in the filtered list, so the
+          # codecov upload condition can actually match a matrix entry.
+          default_ruby_version=$(echo "$combined" | jq -r '.include | map(.ruby) | map(select(.experimental == false)) | .[0].version')
+
+          echo "value=$(echo ${combined} | tr '\n' ' ')" >> $GITHUB_OUTPUT
+          echo "default_ruby_version=${default_ruby_version}" >> $GITHUB_OUTPUT
+
+      - id: repo_status
+        uses: metanorma/ci/gh-repo-status-action@main
+
+  rake-monorepo:
+    name: Test ${{ matrix.gem }} on Ruby ${{ matrix.ruby.version }} ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    needs: prepare
+    if: needs.prepare.outputs.push_for_tag != 'true'
+    concurrency:
+      group: '${{ github.workflow }}-${{ matrix.gem }}-${{ matrix.os }}-${{ matrix.ruby.version }}-${{ github.head_ref || github.ref_name }}'
+      cancel-in-progress: true
+    continue-on-error: ${{ matrix.ruby.experimental }}
+    strategy:
+      fail-fast: false
+      max-parallel: 6
+      matrix: ${{ fromJson(needs.prepare.outputs.combined_matrix) }}
+    defaults:
+      run:
+        working-directory: ${{ format('{0}/{1}', inputs.gem_directory, matrix.gem) }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby.version }}
+          bundler-cache: true
+          rubygems: ${{ matrix.ruby.rubygems }}
+          bundler: ${{ matrix.ruby.bundler }}
+          working-directory: ${{ format('{0}/{1}', inputs.gem_directory, matrix.gem) }}
+
+      - run: bundle exec rake
+
+      - if: needs.prepare.outputs.public == 'true' && matrix.os == 'ubuntu-latest' && matrix.ruby.version == needs.prepare.outputs.default_ruby_version
+        uses: codecov/codecov-action@v4
+        with:
+          file: ${{ format('{0}/{1}/coverage/.resultset.json', inputs.gem_directory, matrix.gem) }}
+
+  tests-passed:
+    needs: rake-monorepo
+    if: always() && (needs.rake-monorepo.result == 'success' || needs.rake-monorepo.result == 'skipped')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: peter-evans/repository-dispatch@v3
+        name: Tests passed
+        with:
+          token: ${{ secrets.pat_token || github.token }}
+          repository: ${{ github.repository }}
+          event-type: ${{ inputs.tests-passed-event }}
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "type": "${{ inputs.tests-passed-event }}"}'
+
+      - if: startsWith(github.ref, 'refs/tags/v')
+        name: Repository ready for release
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.pat_token || github.token }}
+          repository: ${{ github.repository }}
+          event-type: ${{ inputs.release-event }}
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "type": "${{ inputs.release-event }}"}'


### PR DESCRIPTION
## Summary

Adds `.github/workflows/rake-monorepo.yml` — a reusable `workflow_call` that
caller monorepos (`relaton/relaton`, soon `pubid`, possibly others) can
invoke to run `bundle exec rake` per gem on a configurable Ruby × OS matrix.

## Why

Upstream `metanorma/ci/.github/workflows/generic-rake.yml@main` only handles
**single-gem** repos: one `bundle exec rake` in the repo root, no notion of
a `gems/<name>/` layout. Until now, `relaton/relaton` carried its own ~245-
line fork of that workflow with monorepo support glued in. That fork is
about to be deleted (companion PR on `relaton/relaton`) and re-pointed at
this shared workflow, and other relaton-org monorepos can adopt it the
same way.

Symptom this fixes for `relaton/relaton`: every push to `main` failed
(e.g. [run 26308017812](https://github.com/relaton/relaton/actions/runs/26308017812))
because the local fork produced a 35 × 3 × 3 = 315-entry matrix that
exceeded GitHub's 256-job cap, so the entire test job was silently
dropped. The shared workflow lets the caller pass `ruby_versions: \"3.4,4.0\"`
to bring the matrix back under the cap (34 × 2 × 3 = 204).

## Design

**Inputs**

| name | default | purpose |
| --- | --- | --- |
| `gem_directory` | `gems` | directory containing per-gem subdirectories |
| `ruby_versions` | `\"\"` (= all of upstream) | comma-separated allowlist, e.g. `\"3.4,4.0\"` |
| `tests-passed-event` | `tests-passed` | repository-dispatch event name |
| `release-event` | `do-release` | repository-dispatch event name for tagged releases |

**Secrets:** optional `pat_token` (falls back to `github.token`).

**Jobs**

1. `prepare` — checks out the caller, fetches upstream `ruby-matrix.json`,
   applies the `ruby_versions` filter, cross-products with `ls gems/`, emits
   a single `combined_matrix` output. Also derives `default_ruby_version`
   from the **filtered** matrix (= first non-experimental entry's version),
   so the codecov upload gate further down can actually match a matrix
   entry's `matrix.ruby.version`. Upstream `prepare-rake.yml` reads
   `default-ruby-version` from `config.json` as `\"3.3.5\"` (semver) — never
   matches the major.minor of `ruby-matrix.json`, leaving codecov uploads
   silently disabled.
2. `rake-monorepo` — per matrix entry: checkout (`submodules: true`), Ruby
   setup with per-gem `working-directory`, `bundle exec rake`, then a
   conditional codecov upload when `public && ubuntu && default ruby`.
   `continue-on-error: \${{ matrix.ruby.experimental }}` carries over so
   Ruby 4.0 entries don't fail the build.
3. `tests-passed` — `peter-evans/repository-dispatch@v3` to fan out a
   `tests-passed` event, and on tag pushes a second `do-release` event.

## Caller usage

```yaml
# .github/workflows/rake.yml in the caller (monorepo) repo
name: rake
on:
  push: { branches: [main, master], tags: [v*] }
  pull_request: { branches: [main, master] }
concurrency:
  group: \${{ github.workflow }}-\${{ github.head_ref || github.ref_name }}
  cancel-in-progress: true

jobs:
  rake:
    uses: relaton/support/.github/workflows/rake-monorepo.yml@main
    with:
      gem_directory: gems
      ruby_versions: \"3.4,4.0\"
    secrets:
      pat_token: \${{ secrets.RELATON_CI_PAT_TOKEN }}
```

Companion PR on `relaton/relaton` switches that repo to this pattern and
deletes its 245-line local fork.

## Test plan

- [x] Merge this PR.
- [ ] On `relaton/relaton`, merge the companion PR repointing `rake.yml` at
  `relaton/support/.github/workflows/rake-monorepo.yml@main` and deleting
  the local `generic-rake.yml`. Expected on next push:
  - `prepare` succeeds.
  - `rake-monorepo` lists 34 × 2 × 3 = 204 matrix entries and runs them.
  - `tests-passed` runs once the matrix finishes.
  - Codecov uploads fire on `ubuntu-latest` × Ruby 3.4 entries (previously
    permanently skipped).
- [ ] Sweep other relaton-org monorepos (e.g. `pubid`) to adopt the same
  caller pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)