### PR TITLE
fix(data-deploy): add csv gem for Ruby 3.4 jekyll build

### DIFF
--- a/cimas-config/gh-actions/data/Gemfile.deploy
+++ b/cimas-config/gh-actions/data/Gemfile.deploy
@@ -10,6 +10,11 @@ source "https://rubygems.org"
 # Happy Jekylling!
 gem "jekyll", "~> 4.3.2"
 
+# Ruby 3.4 dropped csv from the default gems; jekyll requires it at load time,
+# so it must be an explicit bundle dependency or `bundle exec jekyll` fails with
+# a LoadError.
+gem "csv"
+
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima" # , "~> 2.0"
 # gem "jekyll-theme-minimal"


### PR DESCRIPTION
## Problem

The scheduled **Deploy** workflow fails at the Jekyll build step across `relaton-data-*` repos:

\`\`\`
jekyll-4.3.4/lib/jekyll.rb:28: csv was loaded from the standard library,
  but is not part of the default gems starting from Ruby 3.4.0.
cannot load such file -- csv (LoadError)
\`\`\`

Ruby 3.4 dropped \`csv\` from the default gems (now only a *bundled* gem). The data-deploy workflow was bumped to Ruby 3.4 in a6c0730, so \`bundle exec jekyll build\` can no longer load \`csv\` unless it is declared in the bundle.

Example failure: https://github.com/relaton/relaton-data-w3c/actions/runs/27504966889/job/81294417350

## Fix

Declare \`csv\` explicitly in the \`Gemfile.deploy\` Cimas template. This propagates to every data repo (~27) on the next Cimas sync, fixing all of them at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)